### PR TITLE
Fix scroll overflow using dynamic viewport height

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -81,12 +81,18 @@ html {
 }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
                  'Helvetica Neue', Arial, sans-serif;
     background-color: var(--bg-primary);
     color: var(--text-primary);
     overflow: hidden;
     height: 100vh;
+}
+
+@supports (height: 100dvh) {
+    body {
+        height: 100dvh;
+    }
 }
 
 /* ====================================================================
@@ -106,6 +112,13 @@ body {
     max-width: 800px;
     margin: 0 auto;
     box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+}
+
+@supports (height: 100dvh) {
+    .app-container {
+        min-height: 100dvh;
+        max-height: 100dvh;
+    }
 }
 
 /* ====================================================================
@@ -549,6 +562,13 @@ body {
         margin-bottom: var(--spacing-lg);
         min-height: calc(100vh - 2 * var(--spacing-lg));
         max-height: calc(100vh - 2 * var(--spacing-lg));
+    }
+
+    @supports (height: 100dvh) {
+        .app-container {
+            min-height: calc(100dvh - 2 * var(--spacing-lg));
+            max-height: calc(100dvh - 2 * var(--spacing-lg));
+        }
     }
     
     body {


### PR DESCRIPTION
## Summary
- use dynamic `100dvh` units for body and container heights
- prevent message area from exceeding viewport on desktop

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68beaf7dcc4c83258c16ef9fe11ba43c