### PR TITLE
Remove message fade animation

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -159,17 +159,8 @@ body {
 /* Message Styles */
 .message {
     margin-bottom: var(--spacing-lg);
-    opacity: 0;
-    transform: translateY(20px);
-    animation: messageSlideIn var(--transition-normal) ease forwards;
 }
 
-@keyframes messageSlideIn {
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
 
 .message-header {
     display: flex;


### PR DESCRIPTION
## Summary
- Eliminate hidden message styling by removing fade-in animation in CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf09ead1a48325aaa13ad2c9859be2